### PR TITLE
Handle DataFrames deprecation warning

### DIFF
--- a/src/server.jl
+++ b/src/server.jl
@@ -70,7 +70,7 @@ function query(server::InfluxServer, query_data::Dict; type::Symbol = :get)
     function series_df(series_dict)
         df = DataFrame()
         for name_idx in 1:length(series_dict["columns"])
-            df[Symbol(series_dict["columns"][name_idx])] = [x[name_idx] for x in series_dict["values"]]
+            df[!, Symbol(series_dict["columns"][name_idx])] = [x[name_idx] for x in series_dict["values"]]
         end
         return df
     end


### PR DESCRIPTION
Your InfluxDB module works quite well for me.

This small change addresses:
```Warning: `setindex!(df::DataFrame, v::AbstractVector, col_ind::ColumnIndex)` is deprecated, use `begin
│     df[!, col_ind] = v
│     df
│ end` instead.
│   caller = (::InfluxDB.var"#series_df#17")(::Dict{String,Any}) at server.jl:73
└ @ InfluxDB ~/.julia/packages/InfluxDB/tskcK/src/server.jl:73
```