### PR TITLE
add escaping for writing

### DIFF
--- a/src/database.jl
+++ b/src/database.jl
@@ -7,3 +7,7 @@ end
 function list_databases(server::InfluxServer)
     return query(server, "SHOW DATABASES")
 end
+
+function list_measurements(server::InfluxServer, db::AbstractString)
+    return query(server, "SHOW MEASUREMENTS ON $db")
+end

--- a/src/write.jl
+++ b/src/write.jl
@@ -2,16 +2,16 @@ export Measurement
 
 struct Measurement
     name::String
-    fields::Dict{String,Union{String,Int,Float64}}
+    fields::Dict{String,Union{String,Int,Float64,Bool}}
     tags::Dict{String,String}
     timestamp::Float64
 
-    function Measurement(name::AbstractString, fields::Dict, tags::Dict, timestamp::Float64 = time())
+    function Measurement(name, fields, tags, timestamp = time())
         return new(
             String(name),
             Dict(String(k) => v for (k, v) in fields),
             Dict(String(k) => String(v) for (k, v) in tags),
-            timestamp,
+            Float64(timestamp),
         )
     end
 end
@@ -22,16 +22,32 @@ function payload(m::Measurement)
     return String(take!(buff))
 end
 
-writify(x) = string(x)
-writify(x::AbstractString) = string("\"", x, "\"")
+function check_allowed(x)
+    contains(x, '\n') && error("'\\n' not allowed in " * repr(x))
+    endswith(x, '\\') && error("'\\\\' not allowed at the end of " * repr(x))
+    return true
+end
+
+function escape_measurement(x)
+    check_allowed(x)
+    x = replace(x, r"(\\[ ,=\"])" => s"\\\1")
+    x = replace(x, r"([ ,=\"])" => s"\\\1")
+    return x
+end
+
+escape_tag(x)           = (check_allowed(x) && replace(x, r"([ ,=])" => s"\\\1"))
+escape_tag_key(x)       = (check_allowed(x) && replace(x, r"([ ,=])" => s"\\\1"))
+escape_field_key(x)     = (check_allowed(x) && replace(x, r"([ ,=\"])" => s"\\\1"))
+escape_field(x::String) = '"' * replace(x, r"([\"\\])" => s"\\\1") * '"'
+escape_field(x::Number) = string(x)
 
 function payload!(io::IO, m::Measurement)
-    write(io, m.name)
+    write(io, escape_measurement(m.name))
     if !isempty(m.tags)
-        join(io, [",$(k)=$(v)" for (k, v) in m.tags])
+        join(io, [",$(escape_tag_key(k))=$(escape_tag(v))" for (k, v) in m.tags])
     end
     write(io, " ")
-    join(io, ["$(k)=$(writify(v))" for (k, v) in m.fields], ",")
+    join(io, ["$(escape_field_key(k))=$(escape_field(v))" for (k, v) in m.fields], ",")
     write(io, " ")
     write(io, string(round(Int64, m.timestamp*1e9)))
 end

--- a/test/escaping.jl
+++ b/test/escaping.jl
@@ -6,7 +6,7 @@
     create_database(server, "escape_test")
     
     @testset "Escaping measurement" begin
-        #@test_throws ErrorException escape_measurement("\n")
+        @test_throws ErrorException escape_measurement("\n")
         @test_throws ErrorException escape_measurement("a\\")
 
         tests = [

--- a/test/escaping.jl
+++ b/test/escaping.jl
@@ -1,0 +1,149 @@
+@testset "Escaping" begin
+    import InfluxDB: escape_field, escape_tag, escape_field_key, escape_tag_key, escape_measurement
+    dontescape = join(['a':'z'; 'A':'Z'; '0':'9'; "!#\$%&'()*+-./:;<>?@[]^_`{|}~"; "ᕙ༼*◕_◕*༽ᕤ😆😎😵😗😈🐻💓🌼🎁🎂📱💻"])
+
+    server = InfluxServer("http://localhost:8086")
+    create_database(server, "escape_test")
+    
+    @testset "Escaping measurement" begin
+        #@test_throws ErrorException escape_measurement("\n")
+        @test_throws ErrorException escape_measurement("a\\")
+
+        tests = [
+            dontescape => dontescape
+            "a\\a"     => "a\\a"
+            "b "       => "b\\ "
+            "c,"       => "c\\,"
+            "d="       => "d\\="
+            "e\""      => "e\\\""
+            "f\\\\f"   => "f\\\\f"
+            "g\\ "     => "g\\\\\\ "
+            "h\\,"     => "h\\\\\\,"
+            "i\\="     => "i\\\\\\="
+            "j\\\""    => "j\\\\\\\""
+        ]
+        write(server, "escape_test", Measurement.(first.(tests), Ref(Dict("a"=>"1")), Ref(Dict("b"=>"2"))))
+        meas, = InfluxDB.list_measurements(server, "escape_test")
+
+        for (str, exp) in tests
+            @test escape_measurement(str) == exp
+            @test str ∈ meas.name
+        end
+    end
+
+    @testset "Escaping field" begin
+
+        tests = [
+            dontescape*'\n' => '"' * dontescape*'\n' * '"'
+            "a\\"      => "\"a\\\\\""
+            "b "       => "\"b \""
+            "c,"       => "\"c,\""
+            "d="       => "\"d=\""
+            "e\""      => "\"e\\\"\""
+            "f\\\\"    => "\"f\\\\\\\\\""
+            "g\\ "     => "\"g\\\\ \""
+            "h\\,"     => "\"h\\\\,\""
+            "i\\="     => "\"i\\\\=\""
+            "j\\\""    => "\"j\\\\\\\"\""
+        ]
+        for (i, (str, exp)) in enumerate(tests)
+            @test escape_field(str) == exp
+            write(server, "escape_test", [Measurement("test_field", Dict("a" => str, "i" => i), Dict("b"=>"1"), i)])
+            df, = query(server, "escape_test", SELECT(;measurements=["test_field"], condition="\"i\"=$i"))
+            @test df.a[1] == str
+        end
+        
+        @test escape_field(123) == "123"
+        @test escape_field(1.0) == "1.0"
+        @test escape_field(true) == "true"
+
+        m = Measurement(
+            "test_field",
+            Dict("c" => 123, "d" => 1.4, "e" => false, "i" => 1000),
+            Dict("b" => "1"),
+            1000
+        )
+
+        write(server, "escape_test", [m])
+        df, = query(server, "escape_test", SELECT(;measurements=["test_field"], condition="\"i\"=1000"))
+        @test df.c[1] == 123
+        @test df.d[1] == 1.4
+        @test df.e[1] == false
+    end
+
+    @testset "Escaping tag" begin
+        @test_throws ErrorException escape_tag("\n")
+        @test_throws ErrorException escape_tag("a\\")
+        tests = [
+            dontescape => dontescape
+            "a\\a"     => "a\\a"
+            "b "       => "b\\ "
+            "c,"       => "c\\,"
+            "d="       => "d\\="
+            "e\""      => "e\""
+            "f\\\\f"   => "f\\\\f"
+            "g\\ "     => "g\\\\ "
+            "h\\,"     => "h\\\\,"
+            "i\\="     => "i\\\\="
+            "j\\\""    => "j\\\""
+        ]
+        for (i, (str, exp)) in enumerate(tests)
+            @test escape_tag(str) == exp
+            write(server, "escape_test", [Measurement("test_tag", Dict("i" => i), Dict("a"=>str), i)])
+            df, = query(server, "escape_test", SELECT(;measurements=["test_tag"], condition="\"i\"=$i"))
+            @test df.a[1] == str
+        end
+    end
+
+    @testset "Escaping field key" begin
+        @test_throws ErrorException escape_field_key("\n")
+        @test_throws ErrorException escape_field_key("a\\")
+
+        tests = [
+            dontescape => dontescape
+            "a\\a"     => "a\\a"
+            "b "       => "b\\ "
+            "c,"       => "c\\,"
+            "d="       => "d\\="
+            "e\""      => "e\\\""
+            "f\\\\f"   => "f\\\\f"
+            # "g\\ "     => "g\\\\ " # ???
+            # "h\\,"     => "h\\\\," # ???
+            # "i\\="     => "i\\\\=" # ???
+            # "j\\\""    => "j\\\"" # ???
+        ]
+
+        for (i, (str, exp)) in enumerate(tests)
+            @test escape_field_key(str) == exp
+            write(server, "escape_test", [Measurement("test_field_key", Dict("i" => i, str => true), Dict("a"=>"1"), i)])
+            df, = query(server, "escape_test", SELECT(;measurements=["test_field_key"], condition="\"i\"=$i"))
+            @test str ∈ names(df) && df[1,str] == true
+        end
+    end
+
+    @testset "Escaping tag key" begin
+        @test_throws ErrorException escape_tag_key("\n")
+        @test_throws ErrorException escape_tag_key("a\\")
+
+        tests = [
+            dontescape => dontescape
+            "a\\a"     => "a\\a"
+            "b "       => "b\\ "
+            "c,"       => "c\\,"
+            "d="       => "d\\="
+            "e\""      => "e\""
+            "f\\\\f"   => "f\\\\f"
+            # "g\\ "     => "g\\\\ " # ???
+            # "h\\,"     => "h\\\\," # ???
+            # "i\\="     => "i\\\\=" # ???
+            # "j\\\""    => "j\\\"" # ???
+        ]
+
+        for (i, (str, exp)) in enumerate(tests)
+            @test escape_tag_key(str) == exp
+            write(server, "escape_test", [Measurement("test_tag_key", Dict("i" => i), Dict("a"=>"1", str => "1"), i)])
+            df, = query(server, "escape_test", SELECT(;measurements=["test_tag_key"], condition="\"i\"=$i"))
+            @test str ∈ names(df) && df[1,str] == "1"
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,8 +13,9 @@ try
     include("querying.jl")
     include("databases.jl")
     include("writing.jl")
+    include("escaping.jl")
 finally
-    if container_id != nothing
+    if container_id !== nothing
         @info("Stopping docker influxdb container $(container_id)")
         run(`docker stop $(container_id)`)
     end

--- a/test/writing.jl
+++ b/test/writing.jl
@@ -1,11 +1,11 @@
-@testset "Databases" begin
+@testset "Writing" begin
     server = InfluxServer("http://localhost:8086")
 
     create_database(server, "write_test")
     dbs, = list_databases(server)
     @test "write_test" in dbs[!, :name]
 
-    t = time()
+    t = 2000
     measurements = [
         Measurement(
             "performance",


### PR DESCRIPTION
fix for #10  
this took a lot of time since the escaping rules in the [documentation](https://docs.influxdata.com/influxdb/v1.8/write_protocols/line_protocol_reference/#special-characters) are not clear 

each one of measurement, field value, field key, tag value and tag key has different escaping rules, it's a nightmare
the same should probably be done for querying, which seem to be yet different rules

tested on `inlfuxdb:1.8` and `influxdb:2.0`